### PR TITLE
Fetch the Bitcoin price from BitMEX per minute

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A tool for _extracting_ the BTC price from BitMex and feeding it into redis in a
 Olivia is an oracle that attests to various events.
 In order to attest to an event, it needs to be told about the event's outcome.
 
-When run, `malax` connects to the BitMex API and extracts the hourly Bitcoin price for the given number of hours.
+When run, `malax` connects to the BitMex API and extracts the Bitcoin price per minute for the given number of hours.
 It then sends this price into the given Redis instance which is used by Olivia to attest to the given price.
 
 ## Usage

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,22 +21,30 @@ struct Opts {
 fn main() -> Result<()> {
     let opts = Opts::parse();
 
-    let mut url = reqwest::Url::parse("https://www.bitmex.com/api/v1/instrument/compositeIndex")?;
-    url.query_pairs_mut()
-        .append_pair("symbol", ".BXBT") // only interested in index
-        .append_pair(
-            "filter",
-            r#"{"symbol": ".BXBT", "timestamp.ss": "00", "timestamp.uu": "00"}"#,  // only hourly updates
-        )
-        .append_pair("columns", "lastPrice,timestamp") // only necessary fields
-        .append_pair("reverse", "true") // latest first, allows us to go back in time via `count`
-        .append_pair("count", &opts.past_hours.to_string()); // how many hours to report
+    let mut outcomes = Vec::new();
+    for ResultsPage { count, start } in ResultsPages::new(opts.past_hours as u32).0.iter() {
+        let mut url =
+            reqwest::Url::parse("https://www.bitmex.com/api/v1/instrument/compositeIndex")?;
+        url.query_pairs_mut()
+            .append_pair("symbol", ".BXBT") // only interested in index
+            .append_pair(
+                "filter",
+                r#"{"symbol": ".BXBT", "timestamp.ss": "00", "timestamp.uu": "00"}"#, // only hourly updates
+            )
+            .append_pair("columns", "lastPrice,timestamp") // only necessary fields
+            .append_pair("reverse", "true") // latest first, allows us to go back in time via `count`
+            .append_pair("count", &count.to_string()) // max entries to be returned per page
+            .append_pair("start", &start.to_string()); // starting point for results
 
-    let outcomes = reqwest::blocking::get(url)?
-        .json::<Vec<Quote>>()?
-        .into_iter()
-        .map(BtcUsdBitmexOutcome::new)
-        .collect::<Result<Vec<_>>>()?;
+        let page_outcomes = reqwest::blocking::get(url)?
+            .json::<Vec<Quote>>()?
+            .into_iter()
+            .map(BtcUsdBitmexOutcome::new)
+            .collect::<Result<Vec<_>>>()?;
+
+        outcomes.push(page_outcomes);
+    }
+    let outcomes = outcomes.concat();
 
     let mut redis = redis::Client::open(opts.redis.as_ref())?;
 
@@ -101,5 +109,49 @@ mod rfc3339 {
         let date_time = OffsetDateTime::parse(&string, &Rfc3339).map_err(D::Error::custom)?;
 
         Ok(date_time)
+    }
+}
+
+/// Configuration of paginated results for a BitMEX API.
+struct ResultsPages(Vec<ResultsPage>);
+
+/// Structure of a page of results for a BitMEX API request.
+///
+/// BitMEX API requests can only return 500 elements at a time. In
+/// order to access the entire result space we have to use the `count`
+/// and `start` parameters to paginate.
+struct ResultsPage {
+    /// Number of results in the page.
+    ///
+    /// Maximum value of 500.
+    count: u32,
+    /// Index used as a starting point for the page.
+    start: u32,
+}
+
+impl ResultsPages {
+    /// Maximum number of results returned by BitMEX APIs per page.
+    const BITMEX_MAX_RESULT_COUNT: u32 = 500;
+
+    /// Build a configuration of paginated results based on the total
+    /// number of results wanted in the request.
+    fn new(n_results: u32) -> Self {
+        let full_pages = n_results / Self::BITMEX_MAX_RESULT_COUNT;
+        let partial_page = n_results % Self::BITMEX_MAX_RESULT_COUNT;
+
+        let mut pages = (0..full_pages)
+            .map(|i| ResultsPage {
+                count: Self::BITMEX_MAX_RESULT_COUNT,
+                start: i * Self::BITMEX_MAX_RESULT_COUNT,
+            })
+            .collect::<Vec<_>>();
+        if partial_page != 0 {
+            pages.push(ResultsPage {
+                count: partial_page,
+                start: full_pages * Self::BITMEX_MAX_RESULT_COUNT,
+            });
+        }
+
+        Self(pages)
     }
 }


### PR DESCRIPTION
Fix #1.

The program is still configured based on the number of hours to look in the past, using the argument `past_hours`. But instead of taking hourly intervals, we use minute-long intervals.

cc @Llfourn.