### PR TITLE
Choose index based on CLI argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
  "itoa 1.0.2",
  "libc",
  "num_threads",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ redis = { version = "0.21", default-features = false }
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls-webpki-roots", "blocking", "socks"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-time = { version = "0.3", features = ["std", "parsing", "formatting"] }
+time = { version = "0.3", features = ["std", "parsing", "formatting", "serde-well-known"] }

--- a/README.md
+++ b/README.md
@@ -1,17 +1,25 @@
 # malax
 
-A tool for _extracting_ the BTC price from BitMex and feeding it into redis in an Olivia compatible format.
+A tool for _extracting_ the index prices from BitMex and feeding them into Redis in an Olivia-compatible format.
 
 Olivia is an oracle that attests to various events.
 In order to attest to an event, it needs to be told about the event's outcome.
 
-When run, `malax` connects to the BitMex API and extracts the Bitcoin price per minute for the given number of hours.
+When run, `malax` connects to the BitMex API and extracts the specified index price per minute, for the given number of hours.
 It then sends this price into the given Redis instance which is used by Olivia to attest to the given price.
 
 ## Usage
 
+To get the bitcoin index price over the last 24 hours:
+
 ```bash
-malax --redis redis://localhost:6379 --past-hours 24
+malax --redis redis://localhost:6379 --past-hours 24 btc
+```
+
+To get the eth index price over the last 24 hours:
+
+```bash
+malax --redis redis://localhost:6379 --past-hours 24 eth
 ```
 
 ## What is up with the name?

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use std::str::FromStr;
+
+use anyhow::{bail, Result};
 use clap::Parser;
 use time::{format_description, OffsetDateTime};
 
@@ -6,6 +8,9 @@ use time::{format_description, OffsetDateTime};
 #[clap(author, version, about, long_about = None)]
 #[clap(propagate_version = true)]
 struct Opts {
+    /// The index price for which the historical data will be pulled.
+    index: Index,
+
     /// The redis instance to connect to.
     #[clap(long)]
     redis: String,
@@ -22,15 +27,18 @@ struct Opts {
 fn main() -> Result<()> {
     let opts = Opts::parse();
 
+    let index = opts.index;
+    let symbol = index.as_bitmex_symbol();
+
     let mut outcomes = Vec::new();
     for ResultsPage { count, start } in ResultsPages::new(opts.past_hours * 60).0.iter() {
         let mut url =
             reqwest::Url::parse("https://www.bitmex.com/api/v1/instrument/compositeIndex")?;
         url.query_pairs_mut()
-            .append_pair("symbol", ".BXBT") // only interested in index
+            .append_pair("symbol", &format!(".{symbol}")) // only interested in index
             .append_pair(
                 "filter",
-                r#"{"symbol": ".BXBT", "timestamp.ss": "00"}"#, // per minute
+                &format!("{{\"symbol\": \".{symbol}\", \"timestamp.ss\": \"00\"}}"), // per minute
             )
             .append_pair("columns", "lastPrice,timestamp") // only necessary fields
             .append_pair("reverse", "true") // latest first, allows us to go back in time via `count`
@@ -40,7 +48,7 @@ fn main() -> Result<()> {
         let page_outcomes = reqwest::blocking::get(url)?
             .json::<Vec<Quote>>()?
             .into_iter()
-            .map(BtcUsdBitmexOutcome::new)
+            .map(|quote| BitmexOutcome::new(quote, index))
             .collect::<Result<Vec<_>>>()?;
 
         outcomes.push(page_outcomes);
@@ -63,24 +71,55 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum Index {
+    Btc,
+    Eth,
+}
+
+impl Index {
+    fn as_bitmex_symbol(&self) -> &str {
+        match self {
+            Index::Btc => "BXBT",
+            Index::Eth => "BETH",
+        }
+    }
+}
+
+impl FromStr for Index {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.to_lowercase().as_ref() {
+            "btc" | "bitcoin" => Self::Btc,
+            "eth" | "ether" | "ethereum" => Self::Eth,
+            _ => bail!("Index not supported"),
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize)]
-pub struct BtcUsdBitmexOutcome {
+pub struct BitmexOutcome {
     pub id: String,
     pub outcome: String,
 }
 
-impl BtcUsdBitmexOutcome {
-    fn new(quote: Quote) -> Result<Self> {
+impl BitmexOutcome {
+    fn new(quote: Quote, index: Index) -> Result<Self> {
         let format = format_description::parse("[year]-[month]-[day]T[hour]:[minute]:[second]")?;
 
         Ok(Self {
-            id: format!("/BXBT/{}.price", quote.timestamp.format(&format)?),
+            id: format!(
+                "/{}/{}.price",
+                index.as_bitmex_symbol(),
+                quote.timestamp.format(&format)?
+            ),
             outcome: (quote.last_price as u64).to_string(),
         })
     }
 }
 
-impl redis::ToRedisArgs for BtcUsdBitmexOutcome {
+impl redis::ToRedisArgs for BitmexOutcome {
     fn write_redis_args<W>(&self, out: &mut W)
     where
         W: ?Sized + redis::RedisWrite,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::Parser;
-use time::format_description::well_known::Rfc3339;
 use time::{format_description, OffsetDateTime};
 
 #[derive(Parser)]
@@ -93,25 +92,9 @@ impl redis::ToRedisArgs for BtcUsdBitmexOutcome {
 #[derive(serde::Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct Quote {
-    #[serde(with = "rfc3339")]
+    #[serde(with = "time::serde::rfc3339")]
     timestamp: OffsetDateTime,
     last_price: f64,
-}
-
-mod rfc3339 {
-    use super::*;
-    use serde::de::Error as _;
-    use serde::{Deserialize, Deserializer};
-
-    pub fn deserialize<'a, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
-    where
-        D: Deserializer<'a>,
-    {
-        let string = String::deserialize(deserializer)?;
-        let date_time = OffsetDateTime::parse(&string, &Rfc3339).map_err(D::Error::custom)?;
-
-        Ok(date_time)
-    }
 }
 
 /// Configuration of paginated results for a BitMEX API.


### PR DESCRIPTION
The expectation is that users will call `malax` once per index price.

It's important to note that if the `list` CLI argument is not provided, `malax` will place all outputs in the same Redis list by default.

---

cc @LLFourn 

cc @holzeis @restioson (If you wanna see this tiny repo).